### PR TITLE
Replace semicolons when parsing input file

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -30,7 +30,7 @@ class PtmForm(FlaskForm):
     def file_lines(self):
         if self.has_file_upload and self.csv_file_contents is None:
             self.csv_file_contents = [
-                line.decode() for line in self.csv_file.data.readlines()
+                line.decode().replace(";","+") for line in self.csv_file.data.readlines()
             ]
         return self.csv_file_contents
 


### PR DESCRIPTION
The display of multiphosphorylated site number in the heatmap should not use semi-colon i.e. 112;114, should be 112+114. However, the input should still use a semi-colon because that is MaxQuant ouput. So we need some kind of conversion of ";" to "+" after input.