### PR TITLE
Rename references to default redesign branch

### DIFF
--- a/docs/how-to-drawing-options.md
+++ b/docs/how-to-drawing-options.md
@@ -6,7 +6,7 @@ Options for changing the appearance of the drawing will appear after you click t
 
 Quantitative data can be viewed as either heatmaps below the protein or as lollipops stemming from the protein backbone.
 
-![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/images/draw-opts-vistype.gif)
+![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/images/draw-opts-vistype.gif)
 
 In heatmap view, each protein will be drawn once and experimental trials will appear as rows on the heatmap below each protein. In lollipop view, each protein will be repeated for each experimental trial. Trial labels appear on the far right side of the protein in both visualisation modes.
 
@@ -14,13 +14,13 @@ In heatmap view, each protein will be drawn once and experimental trials will ap
 
 You can horizontally scale the image and the distance between tick marks under the 'image scale' options. By default, the application draws the protein at 1 pixel per amino acid residue (100%) and draws a tick on the scale axis every 500 amino acid residues.
 
-![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/images/draw-opts-scale.gif)
+![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/images/draw-opts-scale.gif)
 
 ## Heatmap
 
 'Minimum' and 'maximum' options allow you to adjust the heatmap range. The 'colour scheme' options allow you to choose from a variety of diverging and sequential colour scales to visualise your data.
 
-![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/images/draw-opts-heatmap.gif)
+![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/images/draw-opts-heatmap.gif)
 
 ## Lollipop
 
@@ -28,4 +28,4 @@ You can increase or decrease the heights of the lollipops by adjusting the 'scal
 
 By default, the lollipops are coloured as they appear in the heatmap view. You can choose to colour the lollipops based on whether they are upregulated (positive intensity) or downregulated (negative intensity) by selecting the 'colour' checkbox.
 
-![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/images/draw-opts-lollipop.gif)
+![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/images/draw-opts-lollipop.gif)

--- a/docs/how-to-submit-data.md
+++ b/docs/how-to-submit-data.md
@@ -83,7 +83,7 @@ tau_rat,542;546;667,phosphorylation,lightgreen
 
 In the example above, there are many modification sites listed, however only one type and lineColour is specified. In cases like these, the type and lineColour values will be repeated for all modification sites specified on that line.
 
-[Download an example CSV file](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/examples/tau_rat_example.csv) to experiment with the schema.
+[Download an example CSV file](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/examples/tau_rat_example.csv) to experiment with the schema.
 This example CSV will generate [this view](#example).
 
 ### My data is from MaxQuant and is site-centric. How do I make it peptide-centric?

--- a/docs/how-to-view-save.md
+++ b/docs/how-to-view-save.md
@@ -2,13 +2,13 @@
 
 In the web application, you can hover your mouse over the heatmap cells or lollipop bulbs to display more information about a specific datum. This is useful for larger jobs where the labels may appear off-screen. Coordinate labels can be repositioned by clicking and dragging the text.
 
-![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/images/draw-opts-interactive.gif)
+![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/images/draw-opts-interactive.gif)
 
 You have the option to customise the drawing in the options pane above the visualisation. See the section 'Drawing options' below for more information.
 
 To download the visualisation as a static image, click the 'download' button below the drawing options pane, then select the output format.
 
-![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/images/download-button.png)
+![](https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/images/download-button.png)
 
 Formats include:
 

--- a/visquant/src/visquant/HelpPage.js
+++ b/visquant/src/visquant/HelpPage.js
@@ -5,7 +5,7 @@ import React from "react";
 const HelpPage = ({ match }) => {
   const { subpage } = match.params;
   const resourceFile = `how-to${subpage ? "-" + subpage : ""}.md`;
-  const resourcePath = `https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/docs/${resourceFile}`;
+  const resourcePath = `https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/docs/${resourceFile}`;
   return <ContentFromMarkdown href={resourcePath} />;
 };
 

--- a/visquant/src/visquant/Page.js
+++ b/visquant/src/visquant/Page.js
@@ -20,7 +20,7 @@ const Page = () => (
           path="/license"
           exact
           component={() => (
-            <ContentFromMarkdown href="https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/redesign/LICENSE.md" />
+            <ContentFromMarkdown href="https://raw.githubusercontent.com/ChildrensMedicalResearchInstitute/ptm-visquant/master/LICENSE.md" />
           )}
         />
         <Route component={PageNotFound} />


### PR DESCRIPTION
Solves #13 

We'll, ideally, need a way to reflect markdown changes within the local dev environment, rather than relying on a live-link to master. I've created #14 to track this.